### PR TITLE
Create artifacts directory before building snapshot

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -75,6 +75,7 @@ tasks:
         fi
         goreleaser check
         TMP_BIN_PATH="{{.DIR_ARTIFACTS}}/provider"
+        mkdir -p "{{.DIR_ARTIFACTS}}"
         goreleaser build --snapshot --clean --single-target -o "${TMP_BIN_PATH}"
         
         METADATA="$(cat "{{.DIR_DIST}}/metadata.json")"


### PR DESCRIPTION
Very small fix for the artifacts directory. 
After a fresh pull of the repo it's not present as all of the contents are ignored by git, but `task build ` was not creating it on the go resulting in error. 